### PR TITLE
Add `runtime_hooks` parameter / documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Are listed in this sections all options available to configure `poetry-pyinstall
 * `argv_emulation` (boolean, **default** `false`) : Enable argv emulation for macOS app bundles. If enabled, the initial open document/URL event is processed by the bootloader and the passed file paths or URLs are appended to sys.argv.
 * `arch` (string, **default** `null`) : Target architecture (macOS only; valid values: x86_64, arm64, universal2).
 * `hiddenimport` (string, **default** `null`) : Hidden imports needed by the program (eg PIL._tkinter_finder for customtkinter).
+* `runtime_hooks` (List[str], **default** `null`): One or more runtime hook paths to bundle with the executable. These hooks are executed before any other code or module to set up special features of the runtime environment.
 
 ### Examples
 
@@ -85,6 +86,9 @@ single-file-bundled = { source = "my_package/main.py", type = "onefile", bundle 
 
 # Folder bundled in wheel
 folder-bundled = { source = "my_package/main.py", type = "onedir", bundle = true}
+
+# Include a runtime hook
+hook-example = { runtime_hooks = ['hooks/my_hook.py'], source = ... }
 
 [tool.poetry-pyinstaller-plugin.certifi]
 # Section dedicated to certifi, required if certificates must be included in certifi store

--- a/poetry_pyinstaller_plugin/plugin.py
+++ b/poetry_pyinstaller_plugin/plugin.py
@@ -77,7 +77,8 @@ class PyInstallerTarget(object):
         uac_uiaccess: bool = False,
         argv_emulation: bool = False,
         arch: Optional[str] = None,
-        hiddenimport: Optional[str] = None
+        hiddenimport: Optional[str] = None,
+        runtime_hooks: Optional[List[str]] = None,
     ):
         self.prog = prog
         self.source = Path(source).resolve()
@@ -94,6 +95,7 @@ class PyInstallerTarget(object):
         self.argv_emulation = argv_emulation
         self.arch = arch
         self.hiddenimport = hiddenimport
+        self.runtime_hooks = runtime_hooks
 
         self._platform = None
 
@@ -162,6 +164,11 @@ class PyInstallerTarget(object):
         if self.hiddenimport:
             args.append("--hidden-import")
             args.append(self.hiddenimport)
+
+        if self.runtime_hooks:
+            for hook in self.runtime_hooks:
+                args.append("--runtime-hook")
+                args.append(hook)
 
         for package in copy_metadata:
             args.append("--copy-metadata")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-pyinstaller-plugin"
-version = "1.1.10"
+version = "1.1.11"
 description = "Poetry plugin to build and/or bundle executable binaries with PyInstaller"
 authors = ["Thomas Mahé <contact@tmahe.dev>"]
 license = "MIT"


### PR DESCRIPTION
Thanks for creating this plugin! Has been great to use so far for a few projects. I needed to use the `runtime_hook` parameter for a script, so figured I'd go ahead and add it since it was pretty straightforward.

Since this parameter can be used multiple times, I opted to use `List[str]`. There are a few other parameters that may work a bit better if they did this too. Happy to submit a PR to fix this too if you'd like.

Let me know how this looks and if you'd like any changes. Thanks!