### PR TITLE
Add support for tool.poetry.include

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Easily create executable binaries from your `pyproject.toml` using [PyInstaller]
 To install `poetry-pyinstaller-plugin` run the following command:
 ```shell
 poetry self add poetry-pyinstaller-plugin
+# or
+pipx inject poetry poetry-pyinstaller-plugin
 ```
 
 If you are having troubles to install the plugin please refer to Poetry documentation: https://python-poetry.org/docs/plugins/#using-plugins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-pyinstaller-plugin"
-version = "1.1.11"
+version = "1.1.12"
 description = "Poetry plugin to build and/or bundle executable binaries with PyInstaller"
 authors = ["Thomas Mahé <contact@tmahe.dev>"]
 license = "MIT"


### PR DESCRIPTION
Closes #10 and added `pipx inject` install method to README as `self add` ["may be problematic"](https://python-poetry.org/docs/plugins/#the-self-add-command) 🤷

Development flow with pipx:
```shell
# install 
pipx runpip poetry install dist/{some_wheel}.whl

# uninstall
pipx runpip poetry uninstall poetry-pyinstaller-plugin
```

---
# Edit
I've kept it as two commits in case a roll back needs to happen. I didn't want to make two pull requests as "extended_includes" requires "includes"

## include_extended explained

The problem with a 1-1 with Poetry's include is that:
1. You cannot include directories, It will loosely place files into `_internal`
2. You cannot put files *next* to the pyinstaller executable. A included README would be placed into `_internal` and with a onefile install it would be worse than useless.
3. You cannot rename files. Ex: `ENDUSER_README.md` -> `README.md`

To add this functionality I've added three new settings:

1. `[poetry-pyinstaller-plugin.exclude-include]` (boolean=false)
    * disables plugin's features for base `poetry.include` packing
2. `[poetry-pyinstaller-plugin.include]` (dict[source, destination])
    * a 1-1 mapping for `--add-data`
    * allows for destination renaming
    * allows for entire directories to be copied
3. `[poetry-pyinstaller-plugin.package]` (dict[source, destination])
    * adds the ability to place files or directories **next** to the pyinstaller executable
    * destination renaming


---
#### [poetry-pyinstaller-plugin.package] caveat
It doesn't support creating nested destinations.

#### Example:    
This **does not** work:
```yaml
[tool.poetry-pyinstaller-plugin.package]
"README.md" = "docs/README.md"  # docs directory doesn't exist!
```
This **does** work:
```yaml
[tool.poetry-pyinstaller-plugin.package]
"docs" = "."                    # create directory
"README.md" = "docs/README.md"  # place into directory
```