### PR TITLE
Use single pip command to install packages & add option `use-poetry-install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Are listed in this sections all options available to configure `poetry-pyinstall
     * Does not support version constraint
   * `exclude-include` (boolean) 
     * Exclude poetry include. Default: `False`
+  * `use-poetry-install` (boolean) 
+    * The default mode `False` installs packages (including "*pyinstaller*", "*certifi*" & "*cffi*") to the actual
+      virtual environment by using internally pip. It will not use `poetry.lock` file, just the dependencies from the
+      `pyproject.toml` configuration file.
+    * When set to `True` the virtual environment should be completely installed by poetry including "*pyinstaller*"
+      and optional "*certifi*" & "*cffi*" (for custom certificates).\
+      This is done by adding them as dependencies to the `pyproject.toml` configuration file and run `poetry install`
+      before starting `poetry build` command. Recommendation is the usage of an separate dependency group for
+      pyinstaller. 
   * `scripts` (dictionary) 
     * Where key is the program name and value a path to script or a `PyInstallerTarget` spec
     * Example: `prog-name = "my_package/script.py"`


### PR DESCRIPTION
The existing method was using a single pip command for every package. 
This could lead to errors, when the user try to fix a library A to a certain version and another library B is also used, which referencing library B (so this will use the latest allowed version of library A). 
Now with the single call the pip command will use the correct versions.

With the option `use-poetry-install` the usage of poetry's `install` command is possible
including lock files. The control of dependency resolution is done
completely by poetry.

This resolves #12.