### PR TITLE
Set logging level of PyInstaller from Poetry build command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
 
   Release:
     runs-on: [ ubuntu-latest ]
-    if: startsWith(github.event.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/master'
     needs: Tests
     steps:
       - uses: actions/checkout@v4
@@ -53,5 +53,6 @@ jobs:
           python -m pip install poetry
       - name: Publish package
         run: |
+          poetry self add "poetry-dynamic-versioning[plugin]"
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish --build

--- a/README.md
+++ b/README.md
@@ -143,6 +143,32 @@ Replacing platform in wheels (manylinux_2_35_x86_64)
   - my_package-0.0.0-py3-none-manylinux_2_35_x86_64.whl
 ```
 
+### Build verbosity settings
+
+Logging verbosity during PyInstaller build phase is configured through `poetry build` command using `--verbose/-v` option.
+
+Available levels:
+* `-v` : Set `--log-level=WARN`
+* `-vv` : Set `--log-level=INFO`
+* `-vvv` : Set `--log-level=DEBUG` & `--debug=all`
+#### Example:
+```text
+$ poetry build --format pyinstaller -v
+Using virtualenv: /home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10
+  - Installing requests (>=2.32.3,<3.0.0)
+Preparing PyInstaller 6.4.0 environment /home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10
+Building binaries with PyInstaller Python 3.10 [manylinux_2_35_x86_64]
+  - Building one-file SINGLE_FILE
+      59 INFO: PyInstaller: 6.4.0, contrib hooks: 2024.7
+      59 INFO: Python: 3.10.12
+      60 INFO: Platform: Linux-6.5.0-41-generic-x86_64-with-glibc2.35
+      60 INFO: wrote dist/pyinstaller/manylinux_2_35_x86_64/.specs/one-file.spec
+      ...
+      4009 INFO: Appending PKG archive to custom ELF section in EXE
+      4020 INFO: Building EXE from EXE-00.toc completed successfully.
+  - Built one-file -> 'dist/pyinstaller/manylinux_2_35_x86_64/one-file'
+```
+
 Expected directory structure:
 ```text
 .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-pyinstaller-plugin"
-version = "1.1.13"
+version = "0.0.0"
 description = "Poetry plugin to build and/or bundle executable binaries with PyInstaller"
 authors = ["Thomas Mahé <contact@tmahe.dev>"]
 license = "MIT"
@@ -27,9 +27,12 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.8,<3.13"
 
+[tool.poetry-dynamic-versioning]
+enable = true
+
 [tool.poetry.plugins."poetry.application.plugin"]
 poetry-pyinstaller-plugin = "poetry_pyinstaller_plugin.plugin:PyInstallerPlugin"
 
 [build-system]
-requires = ["poetry-core>=1.8.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.8.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
Solves GH-22

Use verbosity settings from `poetry build` command to setup PyInstaller logging level.

On `-vvv` (DEBUG level) extra argument is passed to PyInstaller: `--debug=all`

### Example log
```
$ poetry build --format pyinstaller -vvv
Using virtualenv: /home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10
  - Installing requests (>=2.32.3,<3.0.0)
Collecting pyinstaller==6.4.0
  Using cached pyinstaller-6.4.0-py3-none-manylinux2014_x86_64.whl.metadata (8.3 kB)
Collecting certifi
  Using cached certifi-2024.7.4-py3-none-any.whl.metadata (2.2 kB)
Collecting cffi
  Using cached cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
Collecting requests<3.0.0,>=2.32.3
  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
Collecting setuptools>=42.0.0 (from pyinstaller==6.4.0)
  Using cached setuptools-70.3.0-py3-none-any.whl.metadata (5.8 kB)
Collecting altgraph (from pyinstaller==6.4.0)
  Using cached altgraph-0.17.4-py2.py3-none-any.whl.metadata (7.3 kB)
Collecting pyinstaller-hooks-contrib>=2024.0 (from pyinstaller==6.4.0)
  Using cached pyinstaller_hooks_contrib-2024.7-py2.py3-none-any.whl.metadata (16 kB)
Collecting packaging>=22.0 (from pyinstaller==6.4.0)
  Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
Collecting pycparser (from cffi)
  Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
Collecting charset-normalizer<4,>=2 (from requests<3.0.0,>=2.32.3)
  Using cached charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
Collecting idna<4,>=2.5 (from requests<3.0.0,>=2.32.3)
  Using cached idna-3.7-py3-none-any.whl.metadata (9.9 kB)
Collecting urllib3<3,>=1.21.1 (from requests<3.0.0,>=2.32.3)
  Using cached urllib3-2.2.2-py3-none-any.whl.metadata (6.4 kB)
Using cached pyinstaller-6.4.0-py3-none-manylinux2014_x86_64.whl (670 kB)
Using cached certifi-2024.7.4-py3-none-any.whl (162 kB)
Using cached cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (443 kB)
Using cached requests-2.32.3-py3-none-any.whl (64 kB)
Using cached charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (142 kB)
Using cached idna-3.7-py3-none-any.whl (66 kB)
Using cached packaging-24.1-py3-none-any.whl (53 kB)
Using cached pyinstaller_hooks_contrib-2024.7-py2.py3-none-any.whl (341 kB)
Using cached setuptools-70.3.0-py3-none-any.whl (931 kB)
Using cached urllib3-2.2.2-py3-none-any.whl (121 kB)
Using cached altgraph-0.17.4-py2.py3-none-any.whl (21 kB)
Using cached pycparser-2.22-py3-none-any.whl (117 kB)
Installing collected packages: altgraph, urllib3, setuptools, pycparser, packaging, idna, charset-normalizer, certifi, requests, pyinstaller-hooks-contrib, cffi, pyinstaller
Successfully installed altgraph-0.17.4 certifi-2024.7.4 cffi-1.16.0 charset-normalizer-3.3.2 idna-3.7 packaging-24.1 pycparser-2.22 pyinstaller-6.4.0 pyinstaller-hooks-contrib-2024.7 requests-2.32.3 setuptools-70.3.0 urllib3-2.2.2

Preparing PyInstaller 6.4.0 environment /home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10
Building binaries with PyInstaller Python 3.10 [manylinux_2_35_x86_64]
  - Building one-file SINGLE_FILE
      58 INFO: PyInstaller: 6.4.0, contrib hooks: 2024.7
      59 INFO: Python: 3.10.12
      59 INFO: Platform: Linux-6.5.0-41-generic-x86_64-with-glibc2.35
      59 INFO: wrote dist/pyinstaller/manylinux_2_35_x86_64/.specs/one-file.spec
      60 DEBUG: Testing UPX availability ...
      60 DEBUG: UPX is not available.
      60 INFO: Removing temporary files and cleaning cache in /home/.../.cache/pyinstaller
      61 DEBUG: script: /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/main.py
      62 INFO: Extending PYTHONPATH with paths
      ['/home/.../dev/poetry-pyinstaller-plugin/tests/one-file',
       '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages']
      3 DEBUG: discover_hook_directories: Hook directories: ['/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/_pyinstaller_hooks_contrib/hooks/stdhooks', '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/_pyinstaller_hooks_contrib/hooks']
      105 INFO: checking Analysis
      105 INFO: Building Analysis because Analysis-00.toc is non existent
      105 INFO: Initializing module dependency graph...
      106 INFO: Caching module graph hooks...
      110 INFO: Analyzing base_library.zip ...
      110 DEBUG: Collecting submodules for collections
      32 DEBUG: collect_submodules - scanning (sub)package collections
      32 DEBUG: collect_submodules - scanning (sub)package collections in location(s): ['/usr/lib/python3.10/collections']
      195 DEBUG: collect_submodules - found submodules: ['collections', 'collections.abc']
      195 DEBUG: Collecting submodules for encodings
      31 DEBUG: collect_submodules - scanning (sub)package encodings
      31 DEBUG: collect_submodules - scanning (sub)package encodings in location(s): ['/usr/lib/python3.10/encodings']
      285 DEBUG: collect_submodules - found submodules: ['encodings', 'encodings.aliases', 'encodings.ascii', 'encodings.base64_codec', 'encodings.big5', 'encodings.big5hkscs', 'encodings.bz2_codec', 'encodings.charmap', 'encodings.cp037', 'encodings.cp1006', 'encodings.cp1026', 'encodings.cp1125', 'encodings.cp1140', 'encodings.cp1250', 'encodings.cp1251', 'encodings.cp1252', 'encodings.cp1253', 'encodings.cp1254', 'encodings.cp1255', 'encodings.cp1256', 'encodings.cp1257', 'encodings.cp1258', 'encodings.cp273', 'encodings.cp424', 'encodings.cp437', 'encodings.cp500', 'encodings.cp720', 'encodings.cp737', 'encodings.cp775', 'encodings.cp850', 'encodings.cp852', 'encodings.cp855', 'encodings.cp856', 'encodings.cp857', 'encodings.cp858', 'encodings.cp860', 'encodings.cp861', 'encodings.cp862', 'encodings.cp863', 'encodings.cp864', 'encodings.cp865', 'encodings.cp866', 'encodings.cp869', 'encodings.cp874', 'encodings.cp875', 'encodings.cp932', 'encodings.cp949', 'encodings.cp950', 'encodings.euc_jis_2004', 'encodings.euc_jisx0213', 'encodings.euc_jp', 'encodings.euc_kr', 'encodings.gb18030', 'encodings.gb2312', 'encodings.gbk', 'encodings.hex_codec', 'encodings.hp_roman8', 'encodings.hz', 'encodings.idna', 'encodings.iso2022_jp', 'encodings.iso2022_jp_1', 'encodings.iso2022_jp_2', 'encodings.iso2022_jp_2004', 'encodings.iso2022_jp_3', 'encodings.iso2022_jp_ext', 'encodings.iso2022_kr', 'encodings.iso8859_1', 'encodings.iso8859_10', 'encodings.iso8859_11', 'encodings.iso8859_13', 'encodings.iso8859_14', 'encodings.iso8859_15', 'encodings.iso8859_16', 'encodings.iso8859_2', 'encodings.iso8859_3', 'encodings.iso8859_4', 'encodings.iso8859_5', 'encodings.iso8859_6', 'encodings.iso8859_7', 'encodings.iso8859_8', 'encodings.iso8859_9', 'encodings.johab', 'encodings.koi8_r', 'encodings.koi8_t', 'encodings.koi8_u', 'encodings.kz1048', 'encodings.latin_1', 'encodings.mac_arabic', 'encodings.mac_croatian', 'encodings.mac_cyrillic', 'encodings.mac_farsi', 'encodings.mac_greek', 'encodings.mac_iceland', 'encodings.mac_latin2', 'encodings.mac_roman', 'encodings.mac_romanian', 'encodings.mac_turkish', 'encodings.mbcs', 'encodings.oem', 'encodings.palmos', 'encodings.ptcp154', 'encodings.punycode', 'encodings.quopri_codec', 'encodings.raw_unicode_escape', 'encodings.rot_13', 'encodings.shift_jis', 'encodings.shift_jis_2004', 'encodings.shift_jisx0213', 'encodings.tis_620', 'encodings.undefined', 'encodings.unicode_escape', 'encodings.utf_16', 'encodings.utf_16_be', 'encodings.utf_16_le', 'encodings.utf_32', 'encodings.utf_32_be', 'encodings.utf_32_le', 'encodings.utf_7', 'encodings.utf_8', 'encodings.utf_8_sig', 'encodings.uu_codec', 'encodings.zlib_codec']
      353 INFO: Loading module hook 'hook-heapq.py' from '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/PyInstaller/hooks'...
      354 DEBUG: Suppressing import of 'doctest' from module 'heapq' due to excluded import 'doctest' specified in a hook for 'heapq' (or its parent package(s)).
      383 INFO: Loading module hook 'hook-encodings.py' from '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/PyInstaller/hooks'...
      383 DEBUG: Collecting submodules for encodings
      30 DEBUG: collect_submodules - scanning (sub)package encodings
      30 DEBUG: collect_submodules - scanning (sub)package encodings in location(s): ['/usr/lib/python3.10/encodings']
      465 DEBUG: collect_submodules - found submodules: ['encodings', 'encodings.aliases', 'encodings.ascii', 'encodings.base64_codec', 'encodings.big5', 'encodings.big5hkscs', 'encodings.bz2_codec', 'encodings.charmap', 'encodings.cp037', 'encodings.cp1006', 'encodings.cp1026', 'encodings.cp1125', 'encodings.cp1140', 'encodings.cp1250', 'encodings.cp1251', 'encodings.cp1252', 'encodings.cp1253', 'encodings.cp1254', 'encodings.cp1255', 'encodings.cp1256', 'encodings.cp1257', 'encodings.cp1258', 'encodings.cp273', 'encodings.cp424', 'encodings.cp437', 'encodings.cp500', 'encodings.cp720', 'encodings.cp737', 'encodings.cp775', 'encodings.cp850', 'encodings.cp852', 'encodings.cp855', 'encodings.cp856', 'encodings.cp857', 'encodings.cp858', 'encodings.cp860', 'encodings.cp861', 'encodings.cp862', 'encodings.cp863', 'encodings.cp864', 'encodings.cp865', 'encodings.cp866', 'encodings.cp869', 'encodings.cp874', 'encodings.cp875', 'encodings.cp932', 'encodings.cp949', 'encodings.cp950', 'encodings.euc_jis_2004', 'encodings.euc_jisx0213', 'encodings.euc_jp', 'encodings.euc_kr', 'encodings.gb18030', 'encodings.gb2312', 'encodings.gbk', 'encodings.hex_codec', 'encodings.hp_roman8', 'encodings.hz', 'encodings.idna', 'encodings.iso2022_jp', 'encodings.iso2022_jp_1', 'encodings.iso2022_jp_2', 'encodings.iso2022_jp_2004', 'encodings.iso2022_jp_3', 'encodings.iso2022_jp_ext', 'encodings.iso2022_kr', 'encodings.iso8859_1', 'encodings.iso8859_10', 'encodings.iso8859_11', 'encodings.iso8859_13', 'encodings.iso8859_14', 'encodings.iso8859_15', 'encodings.iso8859_16', 'encodings.iso8859_2', 'encodings.iso8859_3', 'encodings.iso8859_4', 'encodings.iso8859_5', 'encodings.iso8859_6', 'encodings.iso8859_7', 'encodings.iso8859_8', 'encodings.iso8859_9', 'encodings.johab', 'encodings.koi8_r', 'encodings.koi8_t', 'encodings.koi8_u', 'encodings.kz1048', 'encodings.latin_1', 'encodings.mac_arabic', 'encodings.mac_croatian', 'encodings.mac_cyrillic', 'encodings.mac_farsi', 'encodings.mac_greek', 'encodings.mac_iceland', 'encodings.mac_latin2', 'encodings.mac_roman', 'encodings.mac_romanian', 'encodings.mac_turkish', 'encodings.mbcs', 'encodings.oem', 'encodings.palmos', 'encodings.ptcp154', 'encodings.punycode', 'encodings.quopri_codec', 'encodings.raw_unicode_escape', 'encodings.rot_13', 'encodings.shift_jis', 'encodings.shift_jis_2004', 'encodings.shift_jisx0213', 'encodings.tis_620', 'encodings.undefined', 'encodings.unicode_escape', 'encodings.utf_16', 'encodings.utf_16_be', 'encodings.utf_16_le', 'encodings.utf_32', 'encodings.utf_32_be', 'encodings.utf_32_le', 'encodings.utf_7', 'encodings.utf_8', 'encodings.utf_8_sig', 'encodings.uu_codec', 'encodings.zlib_codec']
      917 INFO: Loading module hook 'hook-pickle.py' from '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/PyInstaller/hooks'...
      921 DEBUG: Suppressing import of 'doctest' from module 'pickle' due to excluded import 'doctest' specified in a hook for 'pickle' (or its parent package(s)).
      921 DEBUG: Suppressing import of 'argparse' from module 'pickle' due to excluded import 'argparse' specified in a hook for 'pickle' (or its parent package(s)).
      1408 INFO: Caching module dependency graph...
      1427 DEBUG: Adding python files to base_library.zip
      1446 INFO: Running Analysis Analysis-00.toc
      1446 INFO: Looking for Python shared library...
      1487 INFO: Using Python shared library: /lib/x86_64-linux-gnu/libpython3.10.so.1.0
      1487 INFO: Analyzing /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/main.py
      1865 INFO: Loading module hook 'hook-charset_normalizer.py' from '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/_pyinstaller_hooks_contrib/hooks/stdhooks'...
      1905 INFO: Loading module hook 'hook-certifi.py' from '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/_pyinstaller_hooks_contrib/hooks/stdhooks'...
      1905 DEBUG: Collecting data files for certifi
      1906 DEBUG: collect_data_files - Found files: [('/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/certifi/cacert.pem', 'certifi'), ('/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/certifi/py.typed', 'certifi')]
      1941 INFO: Processing module hooks...
      1945 INFO: Performing binary vs. data reclassification (4 entries)
      1946 INFO: Looking for ctypes DLLs
      1947 INFO: Analyzing run-time hooks ...
      1948 INFO: Including run-time hook '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/PyInstaller/hooks/rthooks/pyi_rth_inspect.py'
      1950 DEBUG: Module collection settings: {}
      1998 INFO: Looking for dynamic libraries
      1999 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/libpython3.10.so.1.0'
      2004 DEBUG: Processing dependency, name: 'libexpat.so.1', resolved path: '/lib/x86_64-linux-gnu/libexpat.so.1'
      2004 DEBUG: Collecting dependency '/lib/x86_64-linux-gnu/libexpat.so.1' as 'libexpat.so.1'.
      2004 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2004 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2005 DEBUG: Processing dependency, name: 'libz.so.1', resolved path: '/lib/x86_64-linux-gnu/libz.so.1'
      2005 DEBUG: Collecting dependency '/lib/x86_64-linux-gnu/libz.so.1' as 'libz.so.1'.
      2005 DEBUG: Processing dependency, name: 'libm.so.6', resolved path: '/lib/x86_64-linux-gnu/libm.so.6'
      2005 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libm.so.6' due to global exclusion rules.
      2005 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_contextvars.cpython-310-x86_64-linux-gnu.so'
      2009 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_decimal.cpython-310-x86_64-linux-gnu.so'
      2013 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2013 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2013 DEBUG: Processing dependency, name: 'libmpdec.so.3', resolved path: '/lib/x86_64-linux-gnu/libmpdec.so.3'
      2013 DEBUG: Collecting dependency '/lib/x86_64-linux-gnu/libmpdec.so.3' as 'libmpdec.so.3'.
      2013 DEBUG: Processing dependency, name: 'libm.so.6', resolved path: '/lib/x86_64-linux-gnu/libm.so.6'
      2013 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libm.so.6' due to global exclusion rules.
      2013 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_hashlib.cpython-310-x86_64-linux-gnu.so'
      2016 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2016 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2016 DEBUG: Processing dependency, name: 'libcrypto.so.3', resolved path: '/lib/x86_64-linux-gnu/libcrypto.so.3'
      2016 DEBUG: Collecting dependency '/lib/x86_64-linux-gnu/libcrypto.so.3' as 'libcrypto.so.3'.
      2016 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/resource.cpython-310-x86_64-linux-gnu.so'
      2020 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2020 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2020 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_lzma.cpython-310-x86_64-linux-gnu.so'
      2024 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2024 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2024 DEBUG: Processing dependency, name: 'liblzma.so.5', resolved path: '/lib/x86_64-linux-gnu/liblzma.so.5'
      2024 DEBUG: Collecting dependency '/lib/x86_64-linux-gnu/liblzma.so.5' as 'liblzma.so.5'.
      2025 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_bz2.cpython-310-x86_64-linux-gnu.so'
      2029 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2029 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2029 DEBUG: Processing dependency, name: 'libbz2.so.1.0', resolved path: '/lib/x86_64-linux-gnu/libbz2.so.1.0'
      2029 DEBUG: Collecting dependency '/lib/x86_64-linux-gnu/libbz2.so.1.0' as 'libbz2.so.1.0'.
      2029 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_opcode.cpython-310-x86_64-linux-gnu.so'
      2033 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_multibytecodec.cpython-310-x86_64-linux-gnu.so'
      2037 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2037 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2037 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_codecs_jp.cpython-310-x86_64-linux-gnu.so'
      2041 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2041 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2041 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_codecs_kr.cpython-310-x86_64-linux-gnu.so'
      2045 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2045 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2045 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_codecs_iso2022.cpython-310-x86_64-linux-gnu.so'
      2048 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2048 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2048 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_codecs_cn.cpython-310-x86_64-linux-gnu.so'
      2052 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2052 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2052 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_codecs_tw.cpython-310-x86_64-linux-gnu.so'
      2056 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2056 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2056 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_codecs_hk.cpython-310-x86_64-linux-gnu.so'
      2060 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2060 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2060 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/termios.cpython-310-x86_64-linux-gnu.so'
      2064 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2064 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2064 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_json.cpython-310-x86_64-linux-gnu.so'
      2068 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_queue.cpython-310-x86_64-linux-gnu.so'
      2071 DEBUG: Analyzing binary '/usr/lib/python3.10/lib-dynload/_ssl.cpython-310-x86_64-linux-gnu.so'
      2075 DEBUG: Processing dependency, name: 'libssl.so.3', resolved path: '/lib/x86_64-linux-gnu/libssl.so.3'
      2075 DEBUG: Collecting dependency '/lib/x86_64-linux-gnu/libssl.so.3' as 'libssl.so.3'.
      2075 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2075 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2075 DEBUG: Processing dependency, name: 'libcrypto.so.3', resolved path: '/lib/x86_64-linux-gnu/libcrypto.so.3'
      2075 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libcrypto.so.3' due to prior processing.
      2075 DEBUG: Analyzing binary '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/charset_normalizer/md__mypyc.cpython-310-x86_64-linux-gnu.so'
      2080 DEBUG: Processing dependency, name: 'libpthread.so.0', resolved path: '/lib/x86_64-linux-gnu/libpthread.so.0'
      2080 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libpthread.so.0' due to global exclusion rules.
      2080 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2080 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2080 DEBUG: Analyzing binary '/home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/charset_normalizer/md.cpython-310-x86_64-linux-gnu.so'
      2084 DEBUG: Processing dependency, name: 'libpthread.so.0', resolved path: '/lib/x86_64-linux-gnu/libpthread.so.0'
      2084 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libpthread.so.0' due to global exclusion rules.
      2084 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2084 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2084 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/libexpat.so.1'
      2088 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2088 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2088 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/libz.so.1'
      2092 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2092 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2092 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/libmpdec.so.3'
      2096 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2096 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2096 DEBUG: Processing dependency, name: 'libm.so.6', resolved path: '/lib/x86_64-linux-gnu/libm.so.6'
      2096 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libm.so.6' due to global exclusion rules.
      2096 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/libcrypto.so.3'
      2100 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2100 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2100 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/liblzma.so.5'
      2104 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2104 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2104 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/libbz2.so.1.0'
      2108 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2108 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2108 DEBUG: Analyzing binary '/lib/x86_64-linux-gnu/libssl.so.3'
      2112 DEBUG: Processing dependency, name: 'libc.so.6', resolved path: '/lib/x86_64-linux-gnu/libc.so.6'
      2112 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libc.so.6' due to global exclusion rules.
      2112 DEBUG: Processing dependency, name: 'libcrypto.so.3', resolved path: '/lib/x86_64-linux-gnu/libcrypto.so.3'
      2112 DEBUG: Skipping dependency '/lib/x86_64-linux-gnu/libcrypto.so.3' due to prior processing.
      2125 INFO: Warnings written to /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/build/manylinux_2_35_x86_64/one-file/warn-one-file.txt
      2134 INFO: Graph cross-reference written to /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/build/manylinux_2_35_x86_64/one-file/xref-one-file.html
      2138 INFO: Graph drawing written to /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/build/manylinux_2_35_x86_64/one-file/graph-one-file.dot
      2144 INFO: checking PYZ
      2144 INFO: Building PYZ because PYZ-00.toc is non existent
      2144 INFO: Building PYZ (ZlibArchive) /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/build/manylinux_2_35_x86_64/one-file/PYZ-00.pyz
      2207 INFO: Building PYZ (ZlibArchive) /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/build/manylinux_2_35_x86_64/one-file/PYZ-00.pyz completed successfully.
      2216 INFO: checking PKG
      2216 INFO: Building PKG because PKG-00.toc is non existent
      2216 INFO: Building PKG (CArchive) one-file.pkg
      2218 DEBUG: Compiling python script/module file /home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/PyInstaller/loader/pyiboot01_bootstrap.py
      2219 DEBUG: Compiling python script/module file /home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/PyInstaller/hooks/rthooks/pyi_rth_inspect.py
      2219 DEBUG: Compiling python script/module file /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/main.py
      4049 INFO: Building PKG (CArchive) one-file.pkg completed successfully.
      4051 INFO: Bootloader /home/.../.cache/pypoetry/virtualenvs/one-file-rP3OcWW--py3.10/lib/python3.10/site-packages/PyInstaller/bootloader/Linux-64bit-intel/run_d
      4051 INFO: checking EXE
      4051 INFO: Building EXE because EXE-00.toc is non existent
      4051 INFO: Building EXE from EXE-00.toc
      4052 INFO: Copying bootloader EXE to /home/.../dev/poetry-pyinstaller-plugin/tests/one-file/dist/pyinstaller/manylinux_2_35_x86_64/one-file
      4052 INFO: Appending PKG archive to custom ELF section in EXE
      4072 INFO: Building EXE from EXE-00.toc completed successfully.
  - Built one-file -> 'dist/pyinstaller/manylinux_2_35_x86_64/one-file'
```