### PR TITLE
scripts: target accept list in `hiddenimport` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Are listed in this sections all options available to configure `poetry-pyinstall
 * `uac_uiaccess` (boolean, **default** `false`) : Using this option allows an elevated application to work with Remote Desktop.
 * `argv_emulation` (boolean, **default** `false`) : Enable argv emulation for macOS app bundles. If enabled, the initial open document/URL event is processed by the bootloader and the passed file paths or URLs are appended to sys.argv.
 * `arch` (string, **default** `null`) : Target architecture (macOS only; valid values: x86_64, arm64, universal2).
-* `hiddenimport` (string, **default** `null`) : Hidden imports needed by the program (eg PIL._tkinter_finder for customtkinter).
+* `hiddenimport` (string | list), **default** `null`) : Hidden imports needed by the program (eg PIL._tkinter_finder for customtkinter).
 * `runtime_hooks` (List[str], **default** `null`): One or more runtime hook paths to bundle with the executable. These hooks are executed before any other code or module to set up special features of the runtime environment.
 
 ### Examples

--- a/poetry_pyinstaller_plugin/plugin.py
+++ b/poetry_pyinstaller_plugin/plugin.py
@@ -30,7 +30,7 @@ import sys
 import textwrap
 from importlib import reload
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 from shutil import copytree, copy
 from errno import ENOTDIR, EINVAL, EEXIST
 from importlib.machinery import SourceFileLoader
@@ -83,7 +83,7 @@ class PyInstallerTarget(object):
         uac_uiaccess: bool = False,
         argv_emulation: bool = False,
         arch: Optional[str] = None,
-        hiddenimport: Optional[str] = None,
+        hiddenimport: Optional[Union[str, List[str]]] = None,
         runtime_hooks: Optional[List[str]] = None,
     ):
         self.prog = prog
@@ -187,8 +187,11 @@ class PyInstallerTarget(object):
             args.append("--target-arch")
             args.append(self.arch)
         if self.hiddenimport:
-            args.append("--hidden-import")
-            args.append(self.hiddenimport)
+            if isinstance(self.hiddenimport, str):
+                self.hiddenimport = [self.hiddenimport]
+            for h in self.hiddenimport:
+                args.append("--hidden-import")
+                args.append(h)
 
         if self.runtime_hooks:
             for hook in self.runtime_hooks:

--- a/tests/one-file/pyproject.toml
+++ b/tests/one-file/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.10"
 requests = "^2.32.3"
 
 [tool.poetry-pyinstaller-plugin.scripts]
-one-file = { source = "main.py", type = "onefile"}
+one-file = { source = "main.py", type = "onefile", hiddenimport = ["rich", "requests"]}
 
 [tool.poetry-pyinstaller-plugin]
 version = "6.4.0"


### PR DESCRIPTION
Accept list in target specification in `[tool.poetry-pyinstaller-plugin.scripts]`

Example:
```toml
[tool.poetry-pyinstaller-plugin.scripts]
one-file = { source = "main.py", type = "onefile", hiddenimport = ["rich", "requests"]}
```
![image](https://github.com/user-attachments/assets/3ae2f1df-038a-4177-8e55-14ae5e6f501c)

Missing hidden imports are reported during builds.