### PR TITLE
Bugfix/26 glob missing import

### DIFF
--- a/poetry_pyinstaller_plugin/plugin.py
+++ b/poetry_pyinstaller_plugin/plugin.py
@@ -237,7 +237,7 @@ class PyInstallerTarget(object):
                         raise
 
     def bundle_wheel(self, io):
-        wheels = glob.glob("*-py3-none-any.whl", root_dir="dist")
+        wheels = _glob("*-py3-none-any.whl", root_dir="dist")
         for wheel in wheels:
             if self._platform and self.prog:
                 folder_to_add = Path("dist", "pyinstaller", self._platform, self.prog)


### PR DESCRIPTION
With https://github.com/thmahe/poetry-pyinstaller-plugin/pull/26 the import of the glob package was removed and a custom function _glob was implemented. 

This now leads to the issue: name 'glob' is not defined. 

This pull request now replaces the missed replacement of glob.