### PR TITLE
Fix missing import to make it work with Python 3.8 again

### DIFF
--- a/poetry_pyinstaller_plugin/plugin.py
+++ b/poetry_pyinstaller_plugin/plugin.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 __author__ = "Thomas Mahé <contact@tmahe.dev>"
 
 import enum


### PR DESCRIPTION
In order to make this work again with Python 3.8, annotations need to be imported from __future__ module.