### PR TITLE
Update pyproject.toml Python version limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<=3.13"
+python = ">=3.8,<3.14"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Update Python upper version limit to "<3.14" because when using "<=3.13" all the minor updates for 3.13 are ignored. i.e. 3.13.1 won't work with the plugin.