### PR TITLE
Support false value for `console` and `windowed`

### DIFF
--- a/poetry_pyinstaller_plugin/plugin.py
+++ b/poetry_pyinstaller_plugin/plugin.py
@@ -220,10 +220,10 @@ class PyInstallerTarget(object):
             args.append("--strip")
         if self.noupx:
             args.append("--noupx")
-        if self.console:
-            args.append("--console")
-        if self.windowed:
-            args.append("--windowed")
+
+        args.append("--console" if self.console else "--noconsole")
+        args.append("--windowed" if self.windowed else '--nowindowed')
+        
         if self.icon:
             args.append("--icon")
             args.append(self.icon)


### PR DESCRIPTION
Fix for #41 

* Add `--noconsole` argument to PyInstaller when `console=false`
* Add `--nowindowed` argument to PyInstaller when `windowed=false`