### PR TITLE
Ensure absolute path for `icon` option

### DIFF
--- a/poetry_pyinstaller_plugin/target.py
+++ b/poetry_pyinstaller_plugin/target.py
@@ -125,7 +125,7 @@ class Target(utils.LoggingMixin):
         ]
 
         if self.icon:
-            args.extend(("--icon", self.icon))
+            args.extend(("--icon", Path(self.icon).resolve()))
 
         if self.arch:
             args.extend(("--target-arch", self.arch))

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -175,7 +175,7 @@ class TestUtilityFunctions(TestCase):
             '--uac-admin',
             '--uac-uiaccess',
             '--argv-emulation',
-            '--icon', 'icon.ico',
+            '--icon', str(Path('icon.ico').resolve()),
             '--target-arch', 'amd64',
             '--runtime-hook', 'hooks/my_hook.py',
             '--copy-metadata', 'requests',


### PR DESCRIPTION
Proposed fix for #57. Ensure absolute path to icon is provided to pyinstaller.