### PR TITLE
Fix: Add project_path to Target for out-of-source builds

### DIFF
--- a/poetry_pyinstaller_plugin/plugin.py
+++ b/poetry_pyinstaller_plugin/plugin.py
@@ -69,8 +69,9 @@ class PyInstallerBuildCommand(BuildCommand, utils.LoggingMixin):
 
     def handle(self) -> int:  # pragma: nocover
         env_manager = EnvManager(self._app.poetry, io=self._io)
+        project_path = self._app.project_directory.resolve()
         venv = env_manager.create_venv()
-        venv.run("poetry", "install", "--all-extras", "--all-groups")
+        venv.run("poetry", "--project", f"{project_path}", "install", "--all-extras", "--all-groups")
         venv_version = f"python{venv.version_info[0]}.{venv.version_info[1]}"
         pyinstaller_version = venv.run("pyinstaller", "--version").strip()
 
@@ -97,7 +98,7 @@ class PyInstallerBuildCommand(BuildCommand, utils.LoggingMixin):
 
     def bundle_wheels(self):  # pragma: nocover
         wheels = []
-        output_path = utils.get_output_path(self)
+        output_path = utils.get_output_path(self._app.project_directory.resolve(), self)
         for file in os.listdir(output_path):
             if fnmatch.fnmatch(file, '*-py3-none-any.whl'):
                 wheels.append(file)

--- a/poetry_pyinstaller_plugin/target.py
+++ b/poetry_pyinstaller_plugin/target.py
@@ -25,6 +25,7 @@ from poetry_pyinstaller_plugin import utils
 @dataclasses.dataclass(init=False)
 class Target(utils.LoggingMixin):
     package_version: PEP440Version
+    project_path: Path
     dist_path: Path
     work_path: Path
     platform: str
@@ -69,6 +70,7 @@ class Target(utils.LoggingMixin):
         self.source = (poetry.pyproject_path.parent / self.lookup("source", None)).resolve()
         self.platform = utils.get_platform(poetry)
         self.package_version = self._get_package_version(poetry)
+        self.project_path = poetry.file.path.parent.resolve()
         self.work_path = (poetry.pyproject_path.parent / 'build' / self.platform).resolve()
 
         fields = {
@@ -229,7 +231,7 @@ class Target(utils.LoggingMixin):
         env_manager = EnvManager(poetry, io=self._io)
         venv = env_manager.create_venv()
 
-        self.dist_path = utils.get_output_path(command) / "pyinstaller" / self.platform
+        self.dist_path = utils.get_output_path(self.project_path, command) / "pyinstaller" / self.platform
 
         if self.skip:
             self.warning(f" <info>-</info> Skipping {self.prog} (on {self.when} only)")
@@ -249,12 +251,14 @@ class Target(utils.LoggingMixin):
         self.log(f"  - Built <success>{self.prog}</success>")
 
     def _install_dependencies(self, venv: Env):
-        args = ("poetry", "install")
+        args = ("poetry",
+                "--project", str(self.project_path),
+                "install")
 
         # Install poetry dependency groups
         if isinstance(self.with_poetry_groups, bool):
             if self.with_poetry_groups:
-                args += ("--all-groups", )
+                args += ("--all-groups",)
         elif isinstance(self.with_poetry_groups, list):
             for group in self.with_poetry_groups:
                 args += ("--with", group)
@@ -262,7 +266,7 @@ class Target(utils.LoggingMixin):
         # Install poetry dependency extras
         if isinstance(self.with_poetry_extras, bool):
             if self.with_poetry_extras:
-                args += ("--all-extras", )
+                args += ("--all-extras",)
         elif isinstance(self.with_poetry_extras, list):
             for extra in self.with_poetry_extras:
                 args += ("--extras", extra)

--- a/poetry_pyinstaller_plugin/utils.py
+++ b/poetry_pyinstaller_plugin/utils.py
@@ -78,9 +78,11 @@ def get_base_modules_path(poetry: Poetry) -> List[Path]:
     return [module.base for module in WheelBuilder(poetry)._module.includes]  # noqa
 
 
-def get_output_path(command: BuildCommand) -> Path:
+def get_output_path(project_path: Path, command: BuildCommand) -> Path:
     # True when --output specified
     if dist_path := command.option("output"):  # noqa
+        if dist_path == "dist": # Default
+            return (project_path / dist_path).resolve()
         return Path(dist_path).resolve()
     else:
-        return Path("dist").resolve()
+        return (project_path / Path("dist")).resolve()

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from pathlib import Path
+from tempfile import tempdir
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -314,8 +315,10 @@ class TestUtilityFunctions(TestCase):
         self.target.log = mock_log
         self.mock_venv.run = MagicMock()
         self.target._install_dependencies(self.mock_venv)
+        test_project_path = Path("test_project").resolve()
+        self.target.project_path = test_project_path
 
-        mock_log.assert_any_call("<debug>run 'poetry install --all-groups --all-extras'</debug>")
+        mock_log.assert_any_call(f"<debug>run 'poetry --project {test_project_path} install --all-groups --all-extras'</debug>")
         self.mock_venv.run.assert_called()
 
     def test__install_custom_dependencies(self):
@@ -324,10 +327,11 @@ class TestUtilityFunctions(TestCase):
         self.mock_venv.run = MagicMock()
         self.target.with_poetry_groups = ["internal", "tests"]
         self.target.with_poetry_extras = ["sql"]
+        test_project_path = Path("test_project").resolve()
+        self.target.project_path = test_project_path
 
         self.target._install_dependencies(self.mock_venv)
-
-        mock_log.assert_any_call("<debug>run 'poetry install --with internal --with tests --extras sql'</debug>")
+        mock_log.assert_any_call(f"<debug>run 'poetry --project {test_project_path} install --with internal --with tests --extras sql'</debug>")
         self.mock_venv.run.assert_called()
 
     def test__deploy_certificates(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,10 +100,10 @@ class TestUtilityFunctions(TestCase):
         command = MagicMock()
 
         command.option.return_value = None
-        self.assertEqual(get_output_path(command), Path("dist").resolve())
+        self.assertEqual(get_output_path(Path(), command), Path("dist").resolve())
 
         command.option.return_value = "custom"
-        self.assertEqual(get_output_path(command), Path("custom").resolve())
+        self.assertEqual(get_output_path(Path(), command), Path("custom").resolve())
 
 
 class TestPyProjectConfig(TestCase):


### PR DESCRIPTION
Introduces an explicit `project_path` attribute to the `Target` class, initialized to the parent directory of `pyproject.toml`. This ensures that the plugin always has a clear reference to the project's root directory, resolving issues where relative paths or context were lost when building outside the source tree.

Fixes #63